### PR TITLE
Testing on pleiades: send testreport results using "scp" instead of "mpack"

### DIFF
--- a/run_tests/nasa_ames/test_pleiades_fast1
+++ b/run_tests/nasa_ames/test_pleiades_fast1
@@ -20,8 +20,8 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-SEND="ssh pfe $SavD/mpack"
-ADDR='jm_c@mitgcm.org'
+#SEND="ssh pfe $SavD/mpack" ; ADDR='jm_c@mitgcm.org'
+ SEND="ssh pfe scp" ; ADDR='jm_c@mitgcm.org:testing/MITgcm-test'
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):
@@ -223,7 +223,7 @@ if [ $dblTr -ge 1 ] ; then
   echo " <= fail to compile $nFc experiments"
   options="$options -q"
   if [ $dblTr -eq 2 ] ; then
-    echo -n "Submit second job:" $SubD/test_${dNam}_${sfx}2
+    echo -n "Submit second job: $SubD/test_${dNam}_${sfx}2 , "
     qsub $SubD/test_${dNam}_${sfx}2
     exit 0
   fi

--- a/run_tests/nasa_ames/test_pleiades_fast2
+++ b/run_tests/nasa_ames/test_pleiades_fast2
@@ -20,8 +20,8 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-SEND="ssh pfe $SavD/mpack"
-ADDR='jm_c@mitgcm.org'
+#SEND="ssh pfe $SavD/mpack" ; ADDR='jm_c@mitgcm.org'
+ SEND="ssh pfe scp" ; ADDR='jm_c@mitgcm.org:testing/MITgcm-test'
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):
@@ -223,7 +223,7 @@ if [ $dblTr -ge 1 ] ; then
   echo " <= fail to compile $nFc experiments"
   options="$options -q"
   if [ $dblTr -eq 2 ] ; then
-    echo -n "Submit second job:" $SubD/test_${dNam}_${sfx}2
+    echo -n "Submit second job: $SubD/test_${dNam}_${sfx}2 , "
     qsub $SubD/test_${dNam}_${sfx}2
     exit 0
   fi

--- a/run_tests/nasa_ames/test_pleiades_ieee
+++ b/run_tests/nasa_ames/test_pleiades_ieee
@@ -20,8 +20,8 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-SEND="ssh pfe $SavD/mpack"
-ADDR='jm_c@mitgcm.org'
+#SEND="ssh pfe $SavD/mpack" ; ADDR='jm_c@mitgcm.org'
+ SEND="ssh pfe scp" ; ADDR='jm_c@mitgcm.org:testing/MITgcm-test'
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):
@@ -223,7 +223,7 @@ if [ $dblTr -ge 1 ] ; then
   echo " <= fail to compile $nFc experiments"
   options="$options -q"
   if [ $dblTr -eq 2 ] ; then
-    echo -n "Submit second job:" $SubD/test_${dNam}_${sfx}2
+    echo -n "Submit second job: $SubD/test_${dNam}_${sfx}2 , "
     qsub $SubD/test_${dNam}_${sfx}2
     exit 0
   fi


### PR DESCRIPTION
When testreport results are send with "mpack" this go through the email channel ; but sending email from NAS to the outside of NAS is now disabled (on Dec 23, 2024). This PR switches to an alternative way of sending testreport output,
using "scp" from the front-end (pfe) following a "ssh pfe", which is now allowed by  recent update of `testreport` and `do_tst_2+2` from https://github.com/MITgcm/MITgcm/pull/898 