### PR TITLE
Add test-exp atm gray ll

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Note that regression test set-up are not stored in this repository but instead
 directly in the main MITgcm repos,
 under [verification](https://github.com/MITgcm/MITgcm/tree/master/verification),
 using [testreport](https://mitgcm.readthedocs.io/en/latest/contributing/contributing.html#testreport-utility) run-script,
-with few additional tests from [verifiaction_other](https://github.com/MITgcm/verification_other).
+with few additional tests from [verification_other](https://github.com/MITgcm/verification_other).
 
 ### Content:
 
 1. shell and batch scripts to run regression tests in **run_tests/**
-2. shell scripts to collect in one place resgression test output
+2. shell scripts to collect in one place regression test output
    and update test results [table](https://mitgcm.org/testing-summary/)
    in **collect_tests/**
 

--- a/run_tests/engaging/test_engag_ifc_mp2
+++ b/run_tests/engaging/test_engag_ifc_mp2
@@ -5,7 +5,7 @@
 #SBATCH --mem-per-cpu 4000
 #SBATCH -N 1
 #SBATCH --tasks-per-node 10
-# #SBATCH -x node[360,365]
+# #SBATCH -x node[073,122,124,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/ifcMp2_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/ifcMp2_tst.stdout
 #SBATCH --no-requeue
@@ -37,7 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
 
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='ifcMp2'; dblTr=1
-addExp='atm_strato offline_cheapaml'
+addExp='atm_gray_ll atm_strato offline_cheapaml'
  module add slurm
  module add gcc
  module add engaging/intel/2013.1.046

--- a/run_tests/ref_machine/crontab_jmc
+++ b/run_tests/ref_machine/crontab_jmc
@@ -5,7 +5,7 @@ MAILTO=jmc@ocean.mit.edu
 
 57 23  * * * cd /home/jm_c/test_villon && ./update_scripts && cp -p villon/update_scripts .
 02 00 * * * /home/jm_c/test_villon/villon/test_villon a
-12 00 * * * /home/jm_c/test_villon/villon/test_villon b
+12 02 * * * /home/jm_c/test_villon/villon/test_villon b
 
 #-----------------------------------------------------------
 #-from: jm_c@batsi.mit.edu
@@ -14,7 +14,7 @@ MAILTO=jmc@ocean.mit.edu
 
 55 23  * * * cd /home/jm_c/test_batsi && ./update_scripts && cp -p batsi/update_scripts .
 #10 00 * * * /home/jm_c/test_batsi/batsi/test_batsi a
-#- try to start 6:30 h later:
-40 06 * * * /home/jm_c/test_batsi/batsi/test_batsi a
+#- new ordering, start 5:45 h later:
+55 05 * * * /home/jm_c/test_batsi/batsi/test_batsi a
 
 #===========================================================

--- a/run_tests/ref_machine/test_batsi
+++ b/run_tests/ref_machine/test_batsi
@@ -49,9 +49,8 @@ option=
 
 if test $tst_grp = 'a' ; then
  checkOut=2
- tst_list=''
- tst_list="$tst_list mpa adm mpi"
- tst_list="$tst_list mth+rs gfo+rs"
+#tst_list="mpa adm mpi mth+rs gfo+rs"
+ tst_list="gfo+rs mth+rs mpi adm mpa"
 else
  checkOut=1
  tst_list='adm g77 gfo+rs ifc'
@@ -194,7 +193,7 @@ do
   #- define list of additional experiences to test:
   addExp=''
   if test $typ = 'mpi' ; then
-    addExp="offline_cheapaml atm_strato"
+    addExp="offline_cheapaml atm_gray_ll atm_strato"
     addExp="$addExp global_ocean.gm_k3d"
     addExp="$addExp global_ocean.gm_res"
     addExp="$addExp global_oce_cs32"

--- a/run_tests/ref_machine/test_villon
+++ b/run_tests/ref_machine/test_villon
@@ -49,7 +49,8 @@ option=
 
 if test $tst_grp = 'a' ; then
  checkOut=2
- tst_list='mpa mpi mp2+rs mth'
+#tst_list='mpa mpi mp2+rs mth'
+ tst_list='mpi mpa mp2+rs mth'
 else
  checkOut=1
  tst_list='adm tlm gfo+rs'
@@ -193,7 +194,7 @@ do
   #- define list of additional experiences to test:
   addExp=''
   if test $typ = 'mpi' ; then
-    addExp="offline_cheapaml atm_strato"
+    addExp="offline_cheapaml atm_gray_ll atm_strato"
     addExp="$addExp global_oce_cs32"
     addExp="$addExp global_oce_llc90"
   fi


### PR DESCRIPTION
### Add new additional test-exp "atm_gray_ll"

This new exp. (from "verification_other" git-repos, https://github.com/MITgcm/verification_other , PR 73, merged on 2025-02-02) has been made from previously untested "atm_gray/code_ll" and "atm_gray/inp_ll" set-up and is added here to be tested where former "atm_gray" set-up used to be run (before being moved from "verification_other" to "MITgcm/verification", on 2024-11-26, PR 883), i.e., MPI test on "villon" and "batsi" and MPI+mth intel compiler test on engaging.

Also change test ordering (& timing) on "villon" and "batsi" to reduce load overlap (since both VM are on same machine "zany").
