### PR TITLE
adjust/update all engaging tests:

### DIFF
--- a/run_tests/engaging/test_engag_gfo_adm
+++ b/run_tests/engaging/test_engag_gfo_adm
@@ -6,8 +6,8 @@
 #SBATCH -N 2
 # #SBATCH --exclusive
 #SBATCH --tasks-per-node 16
-# #SBATCH -x node235
-#SBATCH -x node[095,122]
+# #SBATCH -x node[073,122,124,235,335]
+#SBATCH -x node[173,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/gfoAdm_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/gfoAdm_tst.stdout
 #SBATCH --no-requeue
@@ -37,6 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
+TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='gfoAdm'; typ='-adm' ; dblTr=1
 addExp="$addExp global_oce_cs32 global_oce_llc90"
@@ -64,6 +65,10 @@ checkOut=1 ; #options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+
+#- to use a local version:
+# TR_Script="$HERE/local/testreport"
+# RS_Script="$HERE/local/do_tst_2+2"
 
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
@@ -135,8 +140,8 @@ if [ $checkOut -eq 1 ] ; then
       done )
     echo "clean testreport output"
   # echo "clean tst_2+2 + testreport output (+ Makefile_syntax files)"
-  # ( cd $gcmDIR/verification ; ../tools/do_tst_2+2 -clean )
-    ( cd $gcmDIR/verification ; ./testreport $typ -clean )
+  # ( cd $gcmDIR/verification ; $RS_Script -clean )
+    ( cd $gcmDIR/verification ; $TR_Script $typ -clean )
     if test "x$addExp" != x ; then
       ( cd $gcmDIR/verification
         listD=`ls -o | grep '^l' | awk '{print $8}' 2> /dev/null`
@@ -238,22 +243,34 @@ else
   exit
 fi
 
+#-----------------------------------------------------------------------------------------
+# create "mf_file" with list of nodes to use:
+MPI_mFile="mpi_mfile.$$"
+echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
+ srun hostname | sort > $MPI_mFile
+ cat $MPI_mFile
+ echo " <-- end of MPI_mFile file"
+
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 4 -nr -odir ${dNam}-$sfx
+  nFc=`grep -c '^Y . N N ' tr_out.txt`
+  echo " <= fail to compile $nFc experiments"
   options="$options -q"
 fi
 
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+    -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+    -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi
@@ -261,11 +278,17 @@ else retVal=0 ; fi
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"
 # echo " -> skip restart test 'do_tst_2+2'"
-#else
+else
 # echo ''
 #- 3) test restart and report results
-# echo ../tools/do_tst_2+2 -mpi \
+# echo $RS_Script -mpi \
+#   -exe \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv\' -mf $MPI_mFile \
 #   -o ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-# ../tools/do_tst_2+2 -mpi \
+# $RS_Script -mpi \
+#   -exe 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv' -mf $MPI_mFile \
 #   -o ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
+#-----------------------------------------------------------------------------------------
+  echo -n "Remove machine-file MPI_mFile :"
+  rm -f $MPI_mFile
+  echo " rm -f $MPI_mFile : done"
 fi

--- a/run_tests/engaging/test_engag_gfo_tlm
+++ b/run_tests/engaging/test_engag_gfo_tlm
@@ -3,9 +3,11 @@
 #SBATCH -p sched_mit_hill
 #SBATCH -t 06:00:00
 #SBATCH --mem-per-cpu 4000
-#SBATCH -n 6
 #SBATCH -N 2
-# #SBATCH -x node[360,365]
+#SBATCH --tasks-per-node 3
+# #SBATCH -n 6
+# #SBATCH -x node[073,122,124,235,335]
+#SBATCH -x node[173,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/gfoTlm_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/gfoTlm_tst.stdout
 #SBATCH --no-requeue
@@ -35,6 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
+TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='gfoTlm'; typ='-tlm' ; dblTr=1
  module add slurm
@@ -61,6 +64,10 @@ checkOut=1 ; #options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+
+#- to use a local version:
+# TR_Script="$HERE/local/testreport"
+# RS_Script="$HERE/local/do_tst_2+2"
 
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
@@ -132,8 +139,8 @@ if [ $checkOut -eq 1 ] ; then
       done )
     echo "clean testreport output"
   # echo "clean tst_2+2 + testreport output (+ Makefile_syntax files)"
-  # ( cd $gcmDIR/verification ; ../tools/do_tst_2+2 -clean )
-    ( cd $gcmDIR/verification ; ./testreport $typ -clean )
+  # ( cd $gcmDIR/verification ; $RS_Script -clean )
+    ( cd $gcmDIR/verification ; $TR_Script $typ -clean )
     if test "x$addExp" != x ; then
       ( cd $gcmDIR/verification
         listD=`ls -o | grep '^l' | awk '{print $8}' 2> /dev/null`
@@ -217,22 +224,34 @@ else
   exit
 fi
 
+#-----------------------------------------------------------------------------------------
+# create "mf_file" with list of nodes to use:
+MPI_mFile="mpi_mfile.$$"
+echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
+ srun hostname | sort > $MPI_mFile
+ cat $MPI_mFile
+ echo " <-- end of MPI_mFile file"
+
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 2 -nr -odir ${dNam}-$sfx
+  nFc=`grep -c '^Y . N N ' tr_out.txt`
+  echo " <= fail to compile $nFc experiments"
   options="$options -q"
 fi
 
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+    -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ftl\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+    -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ftl' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi
@@ -240,11 +259,17 @@ else retVal=0 ; fi
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"
 # echo " -> skip restart test 'do_tst_2+2'"
-#else
+else
 # echo ''
 #- 3) test restart and report results
-# echo ../tools/do_tst_2+2 -mpi \
+# echo $RS_Script -mpi \
+#   -exe \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv\' -mf $MPI_mFile \
 #   -o ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-# ../tools/do_tst_2+2 -mpi \
+# $RS_Script -mpi \
+#   -exe 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv' -mf $MPI_mFile \
 #   -o ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
+#-----------------------------------------------------------------------------------------
+  echo -n "Remove machine-file MPI_mFile :"
+  rm -f $MPI_mFile
+  echo " rm -f $MPI_mFile : done"
 fi

--- a/run_tests/engaging/test_engag_ifc_mp2
+++ b/run_tests/engaging/test_engag_ifc_mp2
@@ -6,6 +6,7 @@
 #SBATCH -N 1
 #SBATCH --tasks-per-node 10
 # #SBATCH -x node[073,122,124,235,335]
+#SBATCH -x node[173,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/ifcMp2_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/ifcMp2_tst.stdout
 #SBATCH --no-requeue
@@ -35,6 +36,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
+TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='ifcMp2'; dblTr=1
 addExp='atm_gray_ll atm_strato offline_cheapaml'
@@ -65,6 +67,10 @@ checkOut=1 ; #options="$options -do"
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+
+#- to use a local version:
+# TR_Script="$HERE/local/testreport"
+# RS_Script="$HERE/local/do_tst_2+2"
 
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
@@ -101,16 +107,16 @@ module list 2>&1
 echo '================================================================================'
 
 #-
- MPI_MFile="${OUTP}/mf_${sfx}"   #- currently not used
+ MPI_mFile="${OUTP}/mf_${sfx}"   #- currently not used
 #mpiCMD="mpirun -hostfile TR_MFILE -n TR_NPROC ./mitgcmuv"
 #- make the testreport MPI_MFILE:
 #listNODES=`echo $SLURM_NODELIST | sed -e 's/\[/ /' -e 's/\]//' -e 's/,/ /' -e 's/-/ /'`
 # duplicate the 2 listed nodes into a 6 list file:
-#/bin/rm -f $MPI_MFile ; touch $MPI_MFile
+#/bin/rm -f $MPI_mFile ; touch $MPI_mFile
 #for nc in `seq 1 4` ; do pfx=''
 # for nd in $listNODES ; do
 #  if test "x$pfx" = x ; then pfx=$nd ; else
-#    echo "${pfx}${nd}" >> $MPI_MFile
+#    echo "${pfx}${nd}" >> $MPI_mFile
 #  fi
 # done
 #done
@@ -155,8 +161,8 @@ if [ $checkOut -eq 1 ] ; then
         fi
       done )
     echo "clean tst_2+2 + testreport output (+ Makefile_syntax files)"
-    ( cd $gcmDIR/verification ; ../tools/do_tst_2+2 -clean )
-    ( cd $gcmDIR/verification ; ./testreport $typ -clean )
+    ( cd $gcmDIR/verification ; $RS_Script -clean )
+    ( cd $gcmDIR/verification ; $TR_Script $typ -clean )
     ( cd $gcmDIR/verification ; rm -f */build/Makefile_syntax )
     ( cd $gcmDIR/verification ; rm -f */build/port_rand.i */build/ptracers_set_iolabel.i )
     if test "x$addExp" != x ; then
@@ -247,9 +253,9 @@ if [ $dblTr -eq 1 ] ; then
 #- 0) just make all module header ( *__genmod.mod files) using modified Makefile
 #  <-- skip this step
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -259,11 +265,11 @@ fi
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
- #echo ./testreport $options -of $OPTFILE -command \'$mpiCMD\' -mf $MPI_MFile \
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+ #echo $TR_Script $options -of $OPTFILE -command \'$mpiCMD\' -mf $MPI_mFile \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
- #./testreport $options -of $OPTFILE -command "$mpiCMD" -mf $MPI_MFile \
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+ #$TR_Script $options -of $OPTFILE -command "$mpiCMD" -mf $MPI_mFile \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi
@@ -274,10 +280,10 @@ if test "x$retVal" != x0 ; then
 else
   echo ''
 #- 3) test restart and report results
- #echo ../tools/do_tst_2+2 -mpi -exe \'$mpiCMD\' -mf $MPI_MFile \
-  echo ../tools/do_tst_2+2 -mpi \
+ #echo $RS_Script -mpi -exe \'$mpiCMD\' -mf $MPI_mFile \
+  echo $RS_Script -mpi \
     -o ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
- #../tools/do_tst_2+2 -mpi -exe "$mpiCMD" -mf $MPI_MFile \
-  ../tools/do_tst_2+2 -mpi \
+ #$RS_Script -mpi -exe "$mpiCMD" -mf $MPI_mFile \
+  $RS_Script -mpi \
     -o ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
 fi

--- a/run_tests/engaging/test_engag_ifc_mpi
+++ b/run_tests/engaging/test_engag_ifc_mpi
@@ -5,8 +5,8 @@
 #SBATCH --mem-per-cpu 4000
 #SBATCH -N 2
 #SBATCH --tasks-per-node 4
-# #SBATCH -x node122
-# #SBATCH -x node[051,052,065,066]
+# #SBATCH -x node[073,122,124,235,335]
+#SBATCH -x node[173,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/ifcMpi_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/ifcMpi_tst.stdout
 #SBATCH --no-requeue
@@ -36,6 +36,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
+TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='ifcMpi'; dblTr=1
 addExp='global_oce_cs32 global_oce_llc90'
@@ -65,6 +66,10 @@ checkOut=1 ; #options="$options -do"
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+
+#- to use a local version:
+# TR_Script="$HERE/local/testreport"
+# RS_Script="$HERE/local/do_tst_2+2"
 
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
@@ -97,16 +102,16 @@ module list 2>&1
 echo '================================================================================'
 
 #-
- MPI_MFile="${OUTP}/mf_${sfx}"   #- currently not used
+ MPI_mFile="${OUTP}/mf_${sfx}"   #- currently not used
 #mpiCMD="mpirun -hostfile TR_MFILE -n TR_NPROC ./mitgcmuv"
 #- make the testreport MPI_MFILE:
  listNODES=`echo $SLURM_NODELIST | sed -e 's/\[/ /' -e 's/\]//' -e 's/,/ /' -e 's/-/ /'`
 # duplicate the 2 listed nodes into a 6 list file:
- /bin/rm -f $MPI_MFile ; touch $MPI_MFile
+ /bin/rm -f $MPI_mFile ; touch $MPI_mFile
  for nc in `seq 1 4` ; do pfx=''
   for nd in $listNODES ; do
    if test "x$pfx" = x ; then pfx=$nd ; else
-     echo "${pfx}${nd}" >> $MPI_MFile
+     echo "${pfx}${nd}" >> $MPI_mFile
    fi
   done
  done
@@ -151,8 +156,8 @@ if [ $checkOut -eq 1 ] ; then
         fi
       done )
     echo "clean tst_2+2 + testreport output (+ Makefile_syntax files)"
-    ( cd $gcmDIR/verification ; ../tools/do_tst_2+2 -clean )
-    ( cd $gcmDIR/verification ; ./testreport $typ -clean )
+    ( cd $gcmDIR/verification ; $RS_Script -clean )
+    ( cd $gcmDIR/verification ; $TR_Script $typ -clean )
     ( cd $gcmDIR/verification ; rm -f */build/Makefile_syntax )
     ( cd $gcmDIR/verification ; rm -f */build/port_rand.i */build/ptracers_set_iolabel.i )
     if test "x$addExp" != x ; then
@@ -259,17 +264,17 @@ fi
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 0) just make all module header ( *__genmod.mod files) using modified Makefile
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 4 -nc -repl_mk do_make_syntax.sh -obj -dd
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 4 -nc -repl_mk do_make_syntax.sh -obj -dd
   options="$options -q"
 
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -278,11 +283,11 @@ fi
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
- #echo ./testreport $options -of $OPTFILE -command \'$mpiCMD\' -mf $MPI_MFile \
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+ #echo $TR_Script $options -of $OPTFILE -command \'$mpiCMD\' -mf $MPI_mFile \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
- #./testreport $options -of $OPTFILE -command "$mpiCMD" -mf $MPI_MFile \
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+ #$TR_Script $options -of $OPTFILE -command "$mpiCMD" -mf $MPI_mFile \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi
@@ -293,10 +298,10 @@ if test "x$retVal" != x0 ; then
 else
   echo ''
 #- 3) test restart and report results
- #echo ../tools/do_tst_2+2 -mpi -exe \'$mpiCMD\' -mf $MPI_MFile \
-  echo ../tools/do_tst_2+2 -mpi \
+ #echo $RS_Script -mpi -exe \'$mpiCMD\' -mf $MPI_mFile \
+  echo $RS_Script -mpi \
     -o ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
- #../tools/do_tst_2+2 -mpi -exe "$mpiCMD" -mf $MPI_MFile \
-  ../tools/do_tst_2+2 -mpi \
+ #$RS_Script -mpi -exe "$mpiCMD" -mf $MPI_mFile \
+  $RS_Script -mpi \
     -o ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
 fi

--- a/run_tests/engaging/test_engag_op64_adm
+++ b/run_tests/engaging/test_engag_op64_adm
@@ -3,9 +3,11 @@
 #SBATCH -p sched_mit_hill
 #SBATCH -t 06:00:00
 #SBATCH --mem-per-cpu 4000
-#SBATCH -n 6
 #SBATCH -N 2
-#SBATCH -x node[122,175,176,235]
+#SBATCH --tasks-per-node 3
+# #SBATCH -n 6
+# #SBATCH -x node[073,122,124,235,335]
+#SBATCH -x node[173,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/o64Adm_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/o64Adm_tst.stdout
 #SBATCH --no-requeue
@@ -35,6 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
+TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='o64Adm'; typ='-adm' ; dblTr=1
 #- currently, no NetCDF => no pkg/profiles
@@ -62,6 +65,10 @@ checkOut=1 ; #options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+
+#- to use a local version:
+# TR_Script="$HERE/local/testreport"
+# RS_Script="$HERE/local/do_tst_2+2"
 
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
@@ -132,8 +139,8 @@ if [ $checkOut -eq 1 ] ; then
         fi
       done )
     echo "clean testreport output"
-  # ( cd $gcmDIR/verification ; ../tools/do_tst_2+2 -clean )
-    ( cd $gcmDIR/verification ; ./testreport $typ -clean )
+  # ( cd $gcmDIR/verification ; $RS_Script -clean )
+    ( cd $gcmDIR/verification ; $TR_Script $typ -clean )
     if test "x$addExp" != x ; then
       ( cd $gcmDIR/verification
         listD=`ls -o | grep '^l' | awk '{print $8}' 2> /dev/null`
@@ -217,43 +224,61 @@ else
   exit
 fi
 
+#-----------------------------------------------------------------------------------------
+# create "mf_file" with list of nodes to use:
+MPI_mFile="mpi_mfile.$$"
+echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
+ srun hostname | sort > $MPI_mFile
+ cat $MPI_mFile
+ echo " <-- end of MPI_mFile file"
+
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 2 -nr -odir ${dNam}-$sfx
+  nFc=`grep -c '^Y . N N ' tr_out.txt`
+  echo " <= fail to compile $nFc experiments"
   options="$options -q"
 fi
 
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+    -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+    -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi
 
 # exit 0
-  logFile=${OUTP}/tut_tracer_adj.som.log
-  echo -n "-- SLURM_TASKS_PER_NODE= $SLURM_TASKS_PER_NODE ; " >> $logFile
-  date >> $logFile
+# logFile=${OUTP}/tut_tracer_adj.som.log
+# echo -n "-- SLURM_TASKS_PER_NODE= $SLURM_TASKS_PER_NODE ; " >> $logFile
+# date >> $logFile
 # grep 'My Processor Name' tutorial_tracer_adjsens/run/STDOUT.000? \
 #    | sed 's/tutorial_tracer_adjsens\//    /' >> $logFile
-  grep 'My Processor Name' tutorial_tracer_adjsens/tr_run.som81/STDOUT.000? \
-     | sed 's/tutorial_tracer_adjsens\// /'    >> $logFile
+# grep 'My Processor Name' tutorial_tracer_adjsens/tr_run.som81/STDOUT.000? \
+#    | sed 's/tutorial_tracer_adjsens\// /'    >> $logFile
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"
 # echo " -> skip restart test 'do_tst_2+2'"
-#else
+else
 # echo ''
 #- 3) test restart and report results
-# echo ../tools/do_tst_2+2 -mpi \
+# echo $RS_Script -mpi \
+#   -exe \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv\' -mf $MPI_mFile \
 #   -o ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-# ../tools/do_tst_2+2 -mpi \
+# $RS_Script -mpi \
+#   -exe 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv' -mf $MPI_mFile \
 #   -o ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
+#-----------------------------------------------------------------------------------------
+  echo -n "Remove machine-file MPI_mFile :"
+  rm -f $MPI_mFile
+  echo " rm -f $MPI_mFile : done"
 fi

--- a/run_tests/engaging/test_engag_op64_mpi
+++ b/run_tests/engaging/test_engag_op64_mpi
@@ -3,9 +3,11 @@
 #SBATCH -p sched_mit_hill
 #SBATCH -t 06:00:00
 #SBATCH --mem-per-cpu 4000
-#SBATCH -n 6
 #SBATCH -N 2
-#SBATCH -x node[122,175,176,235]
+#SBATCH --tasks-per-node 3
+# #SBATCH -n 6
+# #SBATCH -x node[073,122,124,235,335]
+#SBATCH -x node[173,235,335]
 #SBATCH -e /home/jm_c/test_engaging/output/o64Mpi_tst.stderr
 #SBATCH -o /home/jm_c/test_engaging/output/o64Mpi_tst.stdout
 #SBATCH --no-requeue
@@ -35,6 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
+TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
 dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 sfx='o64Mpi'; dblTr=1
 #- Pb when reading MIXED_LAYER_NML from "data.atm_gray", fail to skip Namelist to read the next one
@@ -62,6 +65,10 @@ checkOut=1 ; #options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+
+#- to use a local version:
+# TR_Script="$HERE/local/testreport"
+# RS_Script="$HERE/local/do_tst_2+2"
 
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
@@ -132,8 +139,8 @@ if [ $checkOut -eq 1 ] ; then
         fi
       done )
     echo "clean tst_2+2 + testreport output"
-    ( cd $gcmDIR/verification ; ../tools/do_tst_2+2 -clean )
-    ( cd $gcmDIR/verification ; ./testreport $typ -clean )
+    ( cd $gcmDIR/verification ; $RS_Script -clean )
+    ( cd $gcmDIR/verification ; $TR_Script $typ -clean )
     if test "x$addExp" != x ; then
       ( cd $gcmDIR/verification
         listD=`ls -o | grep '^l' | awk '{print $8}' 2> /dev/null`
@@ -217,22 +224,34 @@ else
   exit
 fi
 
+#-----------------------------------------------------------------------------------------
+# create "mf_file" with list of nodes to use:
+MPI_mFile="mpi_mfile.$$"
+echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
+ srun hostname | sort > $MPI_mFile
+ cat $MPI_mFile
+ echo " <-- end of MPI_mFile file"
+
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
     -j 2 -nr -odir ${dNam}-$sfx
+  nFc=`grep -c '^Y . N N ' tr_out.txt`
+  echo " <= fail to compile $nFc experiments"
   options="$options -q"
 fi
 
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+    -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+    -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi
@@ -249,8 +268,14 @@ if test "x$retVal" != x0 ; then
 else
   echo ''
 #- 3) test restart and report results
-  echo ../tools/do_tst_2+2 -mpi \
+  echo $RS_Script -mpi \
+    -exe \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv\' -mf $MPI_mFile \
     -o ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ../tools/do_tst_2+2 -mpi \
+  $RS_Script -mpi \
+    -exe 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv' -mf $MPI_mFile \
     -o ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
+#-----------------------------------------------------------------------------------------
+  echo -n "Remove machine-file MPI_mFile :"
+  rm -f $MPI_mFile
+  echo " rm -f $MPI_mFile : done"
 fi


### PR DESCRIPTION
After some Slurm/system/disk updates, some (old ?) `mpirun` command did not always assign the right processes on each node. This set of changes make these tests less likely to fail.
1. use mpirun option "-hostname" for gfortran and Open64 tests;
2. change `gfoTlm` and the 2 Open64 tests to use "--task-per-node 3" (-> always 3 core/node on 2 nodes);
3. set local var `TR_Script` & `RS_Script` for `testreport` & `do_tst_2+2` scripts to run;
4. report number of test that did not compile in first `testreport` (-nr).