### PR TITLE
Easier to specify a subset of tests

### DIFF
--- a/run_tests/engaging/test_engag_gfo_adm
+++ b/run_tests/engaging/test_engag_gfo_adm
@@ -38,7 +38,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git@github.com:$git_repo"
 
 TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=1 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='gfoAdm'; typ='-adm' ; dblTr=1
 addExp="$addExp global_oce_cs32 global_oce_llc90"
  module add slurm
@@ -59,17 +59,18 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=1 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- to use a local version:
   TR_Script="$HERE/local/testreport"
 # RS_Script="$HERE/local/do_tst_2+2"
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
 else
@@ -254,9 +255,9 @@ echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -266,10 +267,10 @@ fi
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?

--- a/run_tests/engaging/test_engag_gfo_tlm
+++ b/run_tests/engaging/test_engag_gfo_tlm
@@ -38,7 +38,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git@github.com:$git_repo"
 
 TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=1 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='gfoTlm'; typ='-tlm' ; dblTr=1
  module add slurm
  module add gcc
@@ -58,17 +58,18 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=1 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- to use a local version:
 # TR_Script="$HERE/local/testreport"
 # RS_Script="$HERE/local/do_tst_2+2"
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
 else
@@ -235,9 +236,9 @@ echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 2 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -247,10 +248,10 @@ fi
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ftl\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ftl' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?

--- a/run_tests/engaging/test_engag_ifc_mp2
+++ b/run_tests/engaging/test_engag_ifc_mp2
@@ -37,7 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git@github.com:$git_repo"
 
 TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=1 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='ifcMp2'; dblTr=1
 addExp='atm_gray_ll atm_strato offline_cheapaml'
  module add slurm
@@ -61,17 +61,18 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=1 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- to use a local version:
 # TR_Script="$HERE/local/testreport"
 # RS_Script="$HERE/local/do_tst_2+2"
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
 else
@@ -253,9 +254,9 @@ if [ $dblTr -eq 1 ] ; then
 #- 0) just make all module header ( *__genmod.mod files) using modified Makefile
 #  <-- skip this step
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -266,10 +267,10 @@ if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
  #echo $TR_Script $options -of $OPTFILE -command \'$mpiCMD\' -mf $MPI_mFile \
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
  #$TR_Script $options -of $OPTFILE -command "$mpiCMD" -mf $MPI_mFile \
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi

--- a/run_tests/engaging/test_engag_ifc_mpi
+++ b/run_tests/engaging/test_engag_ifc_mpi
@@ -37,7 +37,7 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git@github.com:$git_repo"
 
 TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=1 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='ifcMpi'; dblTr=1
 addExp='global_oce_cs32 global_oce_llc90'
  module add slurm
@@ -60,17 +60,18 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -ur4 -match 5" ; fi
 options="$options -devel"
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=1 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- to use a local version:
 # TR_Script="$HERE/local/testreport"
 # RS_Script="$HERE/local/do_tst_2+2"
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
 else
@@ -264,17 +265,17 @@ fi
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 0) just make all module header ( *__genmod.mod files) using modified Makefile
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nc -repl_mk do_make_syntax.sh -obj -dd
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nc -repl_mk do_make_syntax.sh -obj -dd
   options="$options -q"
 
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -284,10 +285,10 @@ if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
  #echo $TR_Script $options -of $OPTFILE -command \'$mpiCMD\' -mf $MPI_mFile \
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
  #$TR_Script $options -of $OPTFILE -command "$mpiCMD" -mf $MPI_mFile \
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
 else retVal=0 ; fi

--- a/run_tests/engaging/test_engag_op64_adm
+++ b/run_tests/engaging/test_engag_op64_adm
@@ -38,10 +38,10 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git@github.com:$git_repo"
 
 TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=1 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='o64Adm'; typ='-adm' ; dblTr=1
 #- currently, no NetCDF => no pkg/profiles
-skipExp="$skipExp global_oce_biogeo_bling"
+fewExp="$fewExp global_oce_biogeo_bling"
  module add open64
  module add mvapich2/open64/64/2.0b
  export MPI_INC_DIR="$MPI_HOME/include"
@@ -59,17 +59,18 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=1 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- to use a local version:
 # TR_Script="$HERE/local/testreport"
 # RS_Script="$HERE/local/do_tst_2+2"
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
 else
@@ -235,9 +236,9 @@ echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 2 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -247,10 +248,10 @@ fi
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv_ad' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?

--- a/run_tests/engaging/test_engag_op64_mpi
+++ b/run_tests/engaging/test_engag_op64_mpi
@@ -38,10 +38,10 @@ tmpFil="/tmp/"`basename $0`".$$"
  #git_repo="git@github.com:$git_repo"
 
 TR_Script='./testreport' ; RS_Script='../tools/do_tst_2+2'
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=1 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='o64Mpi'; dblTr=1
 #- Pb when reading MIXED_LAYER_NML from "data.atm_gray", fail to skip Namelist to read the next one
- skipExp="$skipExp atm_gray"
+ fewExp="$fewExp atm_gray"
  module add open64
  module add mvapich2/open64/64/2.0b
  export MPI_INC_DIR="$MPI_HOME/include"
@@ -59,17 +59,18 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=1 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0 ; dblTr=0
 # dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- to use a local version:
 # TR_Script="$HERE/local/testreport"
 # RS_Script="$HERE/local/do_tst_2+2"
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 if test -d $TST_DIR ; then
   echo "start from TST_DIR='$TST_DIR' at: "`date`
 else
@@ -235,9 +236,9 @@ echo '' ; echo "Using machine-file MPI_mFile='$MPI_mFile' :"
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -j 2 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
@@ -247,10 +248,10 @@ fi
 if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo $TR_Script $options -of $OPTFILE -skd \'$skipExp\' \
+  echo $TR_Script $options -of $OPTFILE $optExp \'$fewExp\' \
     -c \'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv\' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  $TR_Script $options -of $OPTFILE -skd "$skipExp" \
+  $TR_Script $options -of $OPTFILE $optExp "$fewExp" \
     -c 'mpirun -np TR_NPROC -hostfile TR_MFILE ./mitgcmuv' -mf $MPI_mFile \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?

--- a/run_tests/engaging/test_submit_engag
+++ b/run_tests/engaging/test_submit_engag
@@ -71,6 +71,7 @@ logPfix='test_submit'
  #git_repo='altMITgcm'; #git_code='MITgcm66h'
 #-- to get the updated testing scripts (with same "git_repo"):
   git_test='regression_tests'
+  test_branch='master'
 #--
   git_repo="https://github.com/$git_repo"
  #git_repo="git://github.com/$git_repo"
@@ -161,6 +162,13 @@ if [ $updateTst -ge 1 ] ; then
   fi
   #--
   if [ $updateTst -eq 1 ] ; then
+    loc_branch=`(cd $git_test ; git rev-parse --abbrev-ref HEAD 2> /dev/null )`
+    if test $test_branch != $loc_branch ; then
+      echo "In clone ( $git_test ), switching from '$loc_branch' to '$test_branch' :" | tee -a $LOG_FIL
+      ( cd $git_test ; git fetch )				| tee -a $LOG_FIL
+      echo "  and checkout $test_branch :"			| tee -a $LOG_FIL
+      ( cd $git_test ; git checkout $test_branch )		| tee -a $LOG_FIL
+    fi
     echo -n "Updating current clone ( $git_test ) ..."		| tee -a $LOG_FIL
     echo '' >> $LOG_FIL
     ( cd $git_test; git pull )					>> $LOG_FIL 2>&1

--- a/run_tests/nasa_ames/test_pleiades_fast
+++ b/run_tests/nasa_ames/test_pleiades_fast
@@ -1,6 +1,6 @@
 #PBS -S /bin/bash
 #PBS -N tst_fast
-#PBS -l select=1:ncpus=6:mpiprocs=6:model=san
+#PBS -l select=1:ncpus=6:model=sky_ele
 #PBS -l walltime=12:00:00
 #PBS -V
 #PBS -e /u/jcampin/test_pleiades/output/tst_fast.stderr
@@ -19,15 +19,59 @@ echo " running on: "`hostname`
 
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
-SubD="$HERE/nasa_ames" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-SEND="ssh pfe $SavD/mpack"
-ADDR='jm_c@mitgcm.org'
+SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
+#SEND="ssh pfe $SavD/mpack" ; ADDR='jm_c@mitgcm.org'
+ SEND="ssh pfe scp" ; ADDR='jm_c@mitgcm.org:testing/MITgcm-test'
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):
  srcDIR='.'
 #srcDIR=$HERE
 srcCode="MITgcm_today"
+
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
+#sfx='ieee'; dblTr=1
+ sfx='fast'; dblTr=1
+#sfx='fast'; checkOut=2 ; dblTr=2  #- fast-1
+#sfx='fast'; checkOut=0 ; dblTr=1  #- fast-2
+#addExp='global_ocean.gm_k3d global_ocean.gm_res'
+#SubD="$HERE/temp"
+
+ module purge
+#- using older version of Intel Compiler:
+#module load comp-intel/2016.2.181
+#- using newer version of Intel Compiler:
+ module load comp-intel/2020.4.304
+#- for MPI: Ou Wang selection:
+ module load mpi-hpe/mpt.2.28_25Apr23_rhel87
+#module load mpi-hpe/mpt
+#- for MPI and NetCDF:
+#module load mpi-hpe/mpt.2.25
+ module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+#-
+ module list
+
+ OPTFILE="../tools/build_options/linux_amd64_ifort+mpi_ice_nas"
+ options="$typ -MPI 6"
+#options="-j 2 $options"
+#mpiCMD='mpiexec_mpt -np TR_NPROC ./mitgcmuv'
+#- need this to get "staf":
+#export PATH="$PATH:$HOME/bin"
+
+cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
+gcmDIR="MITgcm_$sfx"
+
+dInWeek=`date +%a`
+#if test "x$dInWeek" = xSun ; then options="$options -fast" ; fi
+ if test $sfx = 'fast' ; then options="$options -fast" ; fi
+
+#options="$options -nc" ; checkOut=1 ; dblTr=0
+#options="$options -q"  ; checkOut=0 ; dblTr=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
+
+#- keep a copy of MPI_MFILE:
+#cp -p $PBS_NODEFILE $OUTP"/mf_"$sfx
 
 echo "cd $TST_DISK ; pwd (x2)"
 cd $TST_DISK ; pwd
@@ -43,44 +87,6 @@ if test ! -d $TST_DIR ; then
 fi
 echo "start from TST_DIR='$TST_DIR' at: "`date`
 cd $TST_DIR ; pwd
-
-checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
-#sfx='ifc'
-#sfx='ieee'; dblTr=1
- sfx='fast'; dblTr=1
-#sfx='fast'; checkOut=2 ; dblTr=2  #- fast-1
-#sfx='fast'; checkOut=0 ; dblTr=1  #- fast-2
-#addExp='global_ocean.gm_k3d global_ocean.gm_res'
-
- module purge
-#- using older version of Intel Compiler:
-#module load comp-intel/2016.2.181
-#- using newer version of Intel Compiler:
- module load comp-intel/2020.4.304
-#- for MPI and NetCDF:
- module load mpi-hpe/mpt.2.25
- module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
- module list
-
- OPTFILE="../tools/build_options/linux_amd64_ifort+mpi_ice_nas"
- options="$typ -MPI 6"
-#options="-j 2 $options"
-#mpiCMD='mpiexec_mpt -np TR_NPROC ./mitgcmuv'
-#- need this to get "staf":
-#export PATH="$PATH:$HOME/bin"
-
-dInWeek=`date +%a`
-#if test "x$dInWeek" = xSun ; then options="$options -fast" ; fi
- if test $sfx = 'fast' ; then options="$options -fast" ; fi
-
-#options="$options -nc" ; checkOut=1 ; dblTr=0
-#options="$options -q"  ; checkOut=0 ; dblTr=0
-
-#- keep a copy of MPI_MFILE:
-#cp -p $PBS_NODEFILE $OUTP"/mf_"$sfx
-
-cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
-gcmDIR="MITgcm_$sfx"
 
 if [ $checkOut -eq 1 ] ; then
   if test -d $gcmDIR/CVS ; then
@@ -218,18 +224,20 @@ if [ $dblTr -ge 1 ] ; then
   echo " <= fail to compile $nFc experiments"
   options="$options -q"
   if [ $dblTr -eq 2 ] ; then
-    echo -n "Submit second job:" $SubD/test_${dNam}_${sfx}2
+    echo -n "Submit second job: $SubD/test_${dNam}_${sfx}2 , "
     qsub $SubD/test_${dNam}_${sfx}2
     exit 0
   fi
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
   echo ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send \"$SEND\" -sd $SavD -a $ADDR
   ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send "$SEND" -sd $SavD -a $ADDR
   retVal=$?
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/nasa_ames/test_pleiades_fast1
+++ b/run_tests/nasa_ames/test_pleiades_fast1
@@ -29,23 +29,7 @@ TST_DIR="$TST_DISK/test_${dNam}"
 #srcDIR=$HERE
 srcCode="MITgcm_today"
 
-echo "cd $TST_DISK ; pwd (x2)"
-cd $TST_DISK ; pwd
-if test ! -d $TST_DIR ; then
-   echo -n "Creating a working dir: $TST_DIR ..."
-  #/bin/rm -rf $TST_DIR
-   mkdir $TST_DIR
-   retVal=$?
-   if test "x$retVal" != x0 ; then
-      echo "Error: unable to make dir: $TST_DIR (err=$retVal ) --> Exit"
-      exit 1
-   fi
-fi
-echo "start from TST_DIR='$TST_DIR' at: "`date`
-cd $TST_DIR ; pwd
-
-checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
-#sfx='ifc'
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 #sfx='ieee'; dblTr=1
 #sfx='fast'; dblTr=1
  sfx='fast'; checkOut=2 ; dblTr=2  #- fast-1
@@ -74,18 +58,35 @@ checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 #- need this to get "staf":
 #export PATH="$PATH:$HOME/bin"
 
+cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
+gcmDIR="MITgcm_$sfx"
+
 dInWeek=`date +%a`
 #if test "x$dInWeek" = xSun ; then options="$options -fast" ; fi
  if test $sfx = 'fast' ; then options="$options -fast" ; fi
 
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- keep a copy of MPI_MFILE:
 #cp -p $PBS_NODEFILE $OUTP"/mf_"$sfx
 
-cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
-gcmDIR="MITgcm_$sfx"
+echo "cd $TST_DISK ; pwd (x2)"
+cd $TST_DISK ; pwd
+if test ! -d $TST_DIR ; then
+   echo -n "Creating a working dir: $TST_DIR ..."
+  #/bin/rm -rf $TST_DIR
+   mkdir $TST_DIR
+   retVal=$?
+   if test "x$retVal" != x0 ; then
+      echo "Error: unable to make dir: $TST_DIR (err=$retVal ) --> Exit"
+      exit 1
+   fi
+fi
+echo "start from TST_DIR='$TST_DIR' at: "`date`
+cd $TST_DIR ; pwd
 
 if [ $checkOut -eq 1 ] ; then
   if test -d $gcmDIR/CVS ; then
@@ -229,12 +230,14 @@ if [ $dblTr -ge 1 ] ; then
   fi
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
   echo ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send \"$SEND\" -sd $SavD -a $ADDR
   ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send "$SEND" -sd $SavD -a $ADDR
   retVal=$?
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/nasa_ames/test_pleiades_fast2
+++ b/run_tests/nasa_ames/test_pleiades_fast2
@@ -29,23 +29,7 @@ TST_DIR="$TST_DISK/test_${dNam}"
 #srcDIR=$HERE
 srcCode="MITgcm_today"
 
-echo "cd $TST_DISK ; pwd (x2)"
-cd $TST_DISK ; pwd
-if test ! -d $TST_DIR ; then
-   echo -n "Creating a working dir: $TST_DIR ..."
-  #/bin/rm -rf $TST_DIR
-   mkdir $TST_DIR
-   retVal=$?
-   if test "x$retVal" != x0 ; then
-      echo "Error: unable to make dir: $TST_DIR (err=$retVal ) --> Exit"
-      exit 1
-   fi
-fi
-echo "start from TST_DIR='$TST_DIR' at: "`date`
-cd $TST_DIR ; pwd
-
-checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
-#sfx='ifc'
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 #sfx='ieee'; dblTr=1
 #sfx='fast'; dblTr=1
 #sfx='fast'; checkOut=2 ; dblTr=2  #- fast-1
@@ -74,18 +58,35 @@ checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 #- need this to get "staf":
 #export PATH="$PATH:$HOME/bin"
 
+cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
+gcmDIR="MITgcm_$sfx"
+
 dInWeek=`date +%a`
 #if test "x$dInWeek" = xSun ; then options="$options -fast" ; fi
  if test $sfx = 'fast' ; then options="$options -fast" ; fi
 
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- keep a copy of MPI_MFILE:
 #cp -p $PBS_NODEFILE $OUTP"/mf_"$sfx
 
-cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
-gcmDIR="MITgcm_$sfx"
+echo "cd $TST_DISK ; pwd (x2)"
+cd $TST_DISK ; pwd
+if test ! -d $TST_DIR ; then
+   echo -n "Creating a working dir: $TST_DIR ..."
+  #/bin/rm -rf $TST_DIR
+   mkdir $TST_DIR
+   retVal=$?
+   if test "x$retVal" != x0 ; then
+      echo "Error: unable to make dir: $TST_DIR (err=$retVal ) --> Exit"
+      exit 1
+   fi
+fi
+echo "start from TST_DIR='$TST_DIR' at: "`date`
+cd $TST_DIR ; pwd
 
 if [ $checkOut -eq 1 ] ; then
   if test -d $gcmDIR/CVS ; then
@@ -229,12 +230,14 @@ if [ $dblTr -ge 1 ] ; then
   fi
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
   echo ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send \"$SEND\" -sd $SavD -a $ADDR
   ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send "$SEND" -sd $SavD -a $ADDR
   retVal=$?
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/nasa_ames/test_pleiades_ieee
+++ b/run_tests/nasa_ames/test_pleiades_ieee
@@ -29,23 +29,7 @@ TST_DIR="$TST_DISK/test_${dNam}"
 #srcDIR=$HERE
 srcCode="MITgcm_today"
 
-echo "cd $TST_DISK ; pwd (x2)"
-cd $TST_DISK ; pwd
-if test ! -d $TST_DIR ; then
-   echo -n "Creating a working dir: $TST_DIR ..."
-  #/bin/rm -rf $TST_DIR
-   mkdir $TST_DIR
-   retVal=$?
-   if test "x$retVal" != x0 ; then
-      echo "Error: unable to make dir: $TST_DIR (err=$retVal ) --> Exit"
-      exit 1
-   fi
-fi
-echo "start from TST_DIR='$TST_DIR' at: "`date`
-cd $TST_DIR ; pwd
-
-checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
-#sfx='ifc'
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
  sfx='ieee'; dblTr=1
 #sfx='fast'; dblTr=1
 #sfx='fast'; checkOut=2 ; dblTr=2  #- fast-1
@@ -74,18 +58,35 @@ checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; skipExp=''
 #- need this to get "staf":
 #export PATH="$PATH:$HOME/bin"
 
+cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
+gcmDIR="MITgcm_$sfx"
+
 dInWeek=`date +%a`
 #if test "x$dInWeek" = xSun ; then options="$options -fast" ; fi
  if test $sfx = 'fast' ; then options="$options -fast" ; fi
 
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
 #- keep a copy of MPI_MFILE:
 #cp -p $PBS_NODEFILE $OUTP"/mf_"$sfx
 
-cmdCVS='cvs -d :pserver:cvsanon@mitgcm.org:/u/gcmpack -q'
-gcmDIR="MITgcm_$sfx"
+echo "cd $TST_DISK ; pwd (x2)"
+cd $TST_DISK ; pwd
+if test ! -d $TST_DIR ; then
+   echo -n "Creating a working dir: $TST_DIR ..."
+  #/bin/rm -rf $TST_DIR
+   mkdir $TST_DIR
+   retVal=$?
+   if test "x$retVal" != x0 ; then
+      echo "Error: unable to make dir: $TST_DIR (err=$retVal ) --> Exit"
+      exit 1
+   fi
+fi
+echo "start from TST_DIR='$TST_DIR' at: "`date`
+cd $TST_DIR ; pwd
 
 if [ $checkOut -eq 1 ] ; then
   if test -d $gcmDIR/CVS ; then
@@ -229,12 +230,14 @@ if [ $dblTr -ge 1 ] ; then
   fi
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
   echo ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send \"$SEND\" -sd $SavD -a $ADDR
   ./testreport $options -of $OPTFILE -odir ${dNam}-$sfx \
     -send "$SEND" -sd $SavD -a $ADDR
   retVal=$?
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/nasa_ames/test_submit_pleiades
+++ b/run_tests/nasa_ames/test_submit_pleiades
@@ -71,6 +71,7 @@ logPfix='test_submit'
  #git_repo='altMITgcm'; #git_code='MITgcm66h'
 #-- to get the updated testing scripts (with same "git_repo"):
   git_test='regression_tests'
+  test_branch='master'
 #--
   git_repo="https://github.com/$git_repo"
  #git_repo="git://github.com/$git_repo"
@@ -167,6 +168,13 @@ if [ $updateTst -ge 1 ] ; then
   fi
   #--
   if [ $updateTst -eq 1 ] ; then
+    loc_branch=`(cd $git_test ; git rev-parse --abbrev-ref HEAD 2> /dev/null )`
+    if test $test_branch != $loc_branch ; then
+      echo "In clone ( $git_test ), switching from '$loc_branch' to '$test_branch' :" | tee -a $LOG_FIL
+      ( cd $git_test ; git fetch )				| tee -a $LOG_FIL
+      echo "  and checkout $test_branch :"			| tee -a $LOG_FIL
+      ( cd $git_test ; git checkout $test_branch )		| tee -a $LOG_FIL
+    fi
     echo -n "Updating current clone ( $git_test ) ..."		| tee -a $LOG_FIL
     echo '' >> $LOG_FIL
     ( cd $git_test; git pull )					>> $LOG_FIL 2>&1

--- a/run_tests/svante/test_submit_svante
+++ b/run_tests/svante/test_submit_svante
@@ -70,6 +70,8 @@ logPfix='test_submit'
  #git_repo='altMITgcm'; #git_code='MITgcm66h'
 #-- to get the updated testing scripts (with same "git_repo"):
   git_test='regression_tests'
+  test_branch='master'
+  test_branch='setting_subset_of_tests'
 #--
   git_repo="https://github.com/$git_repo"
  #git_repo="git://github.com/$git_repo"
@@ -180,6 +182,13 @@ if [ $updateTst -ge 1 ] ; then
   fi
   #--
   if [ $updateTst -eq 1 ] ; then
+    loc_branch=`(cd $git_test ; git rev-parse --abbrev-ref HEAD 2> /dev/null )`
+    if test $test_branch != $loc_branch ; then
+      echo "In clone ( $git_test ), switching from '$loc_branch' to '$test_branch' :" | tee -a $LOG_FIL
+      ( cd $git_test ; git fetch )				| tee -a $LOG_FIL
+      echo "  and checkout $test_branch :"			| tee -a $LOG_FIL
+      ( cd $git_test ; git checkout $test_branch )		| tee -a $LOG_FIL
+    fi
     echo -n "Updating current clone ( $git_test ) ..."		| tee -a $LOG_FIL
     echo '' >> $LOG_FIL
     ( cd $git_test; git pull )					>> $LOG_FIL 2>&1

--- a/run_tests/svante/test_svante_ifc_adm
+++ b/run_tests/svante/test_svante_ifc_adm
@@ -44,7 +44,7 @@ srcCode="MITgcm_today"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='ifcAdm'; typ='-adm' ; dblTr=1
  module add intel/2021.4.0
  module add openmpi
@@ -62,12 +62,14 @@ dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 2 ] ; then options="$options -ur4" ; fi
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=2 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 echo "cd $TST_DISK ; pwd (x1)"
 cd $TST_DISK
 pwd ; ls -l
@@ -247,33 +249,35 @@ if [ $dblTr -eq 1 ] ; then
  if [ $dAlt -ne 1 ] ; then
   echo ''
 #- 0) just make all module header ( *__genmod.mod files) using modified Makefile
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -repl_mk do_make_syntax.sh -obj -dd
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -repl_mk do_make_syntax.sh -obj -dd 2>&1
   options="$options -q"
  fi
 
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
  if [ $dAlt -eq 1 ] ; then options="$options -q" ; fi
 fi
 
+if [ $dblTr -ge 0 ] ; then
   if [ $dAlt -eq 2 ] ; then options="$options -match 5" ; fi
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
   $HERE/${dNam}/backup_outp tr_${dNam}-${sfx} $OUTP/backup
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/svante/test_svante_ifc_mpi
+++ b/run_tests/svante/test_svante_ifc_mpi
@@ -44,7 +44,7 @@ srcCode="MITgcm_today"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='ifcMpi'; dblTr=1
  module add intel/2021.4.0
  module add openmpi
@@ -61,12 +61,14 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=2 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1 ; dblTr=0
 #options="$options -q"  ; checkOut=0 ; dblTr=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 echo "cd $TST_DISK ; pwd (x1)"
 cd $TST_DISK
 pwd ; ls -l
@@ -246,32 +248,34 @@ if [ $dblTr -eq 1 ] ; then
  if [ $dAlt -ne 1 ] ; then
   echo ''
 #- 0) just make all module header ( *__genmod.mod files) using modified Makefile
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -repl_mk do_make_syntax.sh -obj -dd
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -repl_mk do_make_syntax.sh -obj -dd 2>&1
   options="$options -q"
  fi
 
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   nFc=`grep -c '^Y . N N ' tr_out.txt`
   echo " <= fail to compile $nFc experiments"
  if [ $dAlt -eq 1 ] ; then options="$options -q" ; fi
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
   $HERE/${dNam}/backup_outp tr_${dNam}-${sfx} $OUTP/backup
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/svante/test_svante_ifc_mpi
+++ b/run_tests/svante/test_svante_ifc_mpi
@@ -59,6 +59,7 @@ sfx='ifcMpi'; dblTr=1
 
 gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
+if [ $dAlt -eq 2 ] ; then options="$options -ur4" ; fi
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
 
@@ -267,6 +268,7 @@ if [ $dblTr -eq 1 ] ; then
 fi
 
 if [ $dblTr -ge 0 ] ; then
+  if [ $dAlt -eq 2 ] ; then options="$options -match 5" ; fi
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
   echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \

--- a/run_tests/svante/test_svante_pgi_adm
+++ b/run_tests/svante/test_svante_pgi_adm
@@ -44,7 +44,7 @@ srcCode="MITgcm_today"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='pgiAdm'; typ='-adm'
  module add pgi/16.9
  module add openmpi
@@ -60,12 +60,14 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=2 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 echo "cd $TST_DISK ; pwd (x1)"
 cd $TST_DISK
 pwd ; ls -l
@@ -242,21 +244,23 @@ fi
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   options="$options -q"
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
   $HERE/${dNam}/backup_outp tr_${dNam}-${sfx} $OUTP/backup
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/svante/test_svante_pgi_mpi
+++ b/run_tests/svante/test_svante_pgi_mpi
@@ -44,7 +44,7 @@ srcCode="MITgcm_today"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='pgiMpi'
  module add pgi/16.9
  module add openmpi
@@ -60,12 +60,14 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=2 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 echo "cd $TST_DISK ; pwd (x1)"
 cd $TST_DISK
 pwd ; ls -l
@@ -242,21 +244,23 @@ fi
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 4" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 4 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 4 -nr -odir ${dNam}-$sfx
   options="$options -q"
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
   $HERE/${dNam}/backup_outp tr_${dNam}-${sfx} $OUTP/backup
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"

--- a/run_tests/svante/test_svante_pgi_mth
+++ b/run_tests/svante/test_svante_pgi_mth
@@ -44,9 +44,9 @@ srcCode="MITgcm_today"
  #git_repo="git://github.com/$git_repo"
  #git_repo="git@github.com:$git_repo"
 
-dblTr=0 ; typ='' ; addExp='' ; skipExp=''
+checkOut=2 ; dblTr=0 ; typ='' ; addExp='' ; fewExp='' ; optExp='-skd'
 sfx='pgiMth'
-skipExp='internal_wave tutorial_advection_in_gyre'
+fewExp='internal_wave tutorial_advection_in_gyre'
  module add pgi/16.9
 #module add openmpi
  module add netcdf
@@ -63,12 +63,14 @@ gcmDIR="MITgcm_$sfx"
 dAlt=`date +%d` ; dAlt=`expr $dAlt % 3`
 if [ $dAlt -eq 1 ] ; then options="$options -fast"
 else options="$options -devel" ; fi
-if test "x$skipExp" != x ; then skipExp=`echo $skipExp | sed 's/^ *//'` ; fi
 
-checkOut=2 ; #options="$options -do"
+#options="$options -do"
 #options="$options -nc" ; checkOut=1
 #options="$options -q"  ; checkOut=0
+# dblTr=-1 #- skip testreport completely (only run "do_tst_2+2")
+# optExp='-t' ; fewExp='global_ocean.cs32x15 lab_sea'
 
+if test "x$fewExp" != x ; then fewExp=`echo $fewExp | sed 's/^ *//'` ; fi
 echo "cd $TST_DISK ; pwd (x1)"
 cd $TST_DISK
 pwd ; ls -l
@@ -245,21 +247,23 @@ fi
 if [ $dblTr -eq 1 ] ; then
   echo ''
 #- 1) just compile ("-nr"), using "-j 2" to speed up
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -j 2 -nr -odir ${dNam}-$sfx
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -j 2 -nr -odir ${dNam}-$sfx
   options="$options -q"
 fi
 
+if [ $dblTr -ge 0 ] ; then
   echo ''
 #- 2) run and report results ; also finish to compile those who failed with "-j"
-  echo ./testreport $options -of $OPTFILE -skd \'$skipExp\' \
+  echo ./testreport $options -of $OPTFILE $optExp \'$fewExp\' \
     -odir ${dNam}-$sfx -send \'$SEND\' -sd $SavD -a jm_c@mitgcm.org
-  ./testreport $options -of $OPTFILE -skd "$skipExp" \
+  ./testreport $options -of $OPTFILE $optExp "$fewExp" \
     -odir ${dNam}-$sfx -send "$SEND" -sd $SavD -a jm_c@mitgcm.org
   retVal=$?
   $HERE/${dNam}/backup_outp tr_${dNam}-${sfx} $OUTP/backup
+else retVal=0 ; fi
 
 if test "x$retVal" != x0 ; then
   echo "<== testreport returned retVal=${retVal}, expecting 0"


### PR DESCRIPTION
In `run_test`, update testing scripts for engaging, pleiades and svante:
1. rename $skipExp --> $fewExp + add switch for "-skd" (to turn to "-t")
2. implement dblTr=-1 across all scripts (to just run `do_tst_2+2`)
3.  reduce differences between diffetent scripts
4. allow to switch branch from regression_test clone

And for intel-MPI test on svante, test "-ur4" once every 3 days