### PR TITLE
Test latest tapenade version on baudelaire

### DIFF
--- a/collect_tests/check_outp
+++ b/collect_tests/check_outp
@@ -470,15 +470,15 @@ for pname in $MACHINES ; do
 	    num=`grep -c "^$key" $TMP.plist`
 	  fi
 	  #- discard unsafe test:
-	  dd=`echo $optf | grep -c 'gfortran+mth'`
+	  #dd=`echo $optf | grep -c 'gfortran+mth'`
 	  #if test $mname = 'lagoon' -a $dd = 1 ; then num=-1 ; fi
-	  #if test $mname = 'harbor' -a $dd = 1 ; then num=-1 ; fi
-	  #if test $mname = 'aces' -a $optf = 'linux_ia32_open64' ; then num=-1 ; fi
 	  #if test $mname = 'aces' -a $optf = 'linux_ia32_g95' ; then num=-1 ; fi
-	  dd=`echo $optf | grep -c 'bigred.*noieee'`
-	  #if test $mname = 'bigred' -a $dd = 1 ; then num=-1 ; fi
+	  # dd=`echo $optf | grep -c 'linux_amd64_ifort+impi_engaging.fast'`
+	  # if test $dd = 1 -a $mname = 'engaging1' -a $type = 'restart' ; then num=-1 ; fi
+	  dd=`echo $sdir | grep -v 'engaging1-darwin3' | grep -c 'rs_engaging1-'`
+	  # if test $dd = 1 ; then num=-1 ; fi
 	  if test $num -lt 0 ; then
-	    echo "  discard $sdir : $type , of='$optf'" | tee -a $OUTPFIL
+	    echo "-> discard: $sdir : $type , of='$optf'" | tee -a $OUTPFIL
 	    cmis=`expr $cmis + 1`
 	  elif test $num = '0' ; then
 	    echo "  dir='$sdir', type='$type', of='$optf':" | tee -a $OUTPFIL

--- a/run_tests/ref_machine/set_tapenade.sh
+++ b/run_tests/ref_machine/set_tapenade.sh
@@ -2,6 +2,6 @@
 
 #- set environnement variables to use locally installed Tapenade
 
-    PATH="${PATH}:/home/jm_c/install/tapenade_3.16/bin";
-   #PATH="${PATH}:/home/jm_c/install/tapenade_3.16.v2/bin";
+   #PATH="${PATH}:/home/jm_c/install/tapenade_3.16/bin";
+    PATH="${PATH}:/home/jm_c/test_baudelaire/tapenade_3.16/bin"
     export PATH

--- a/run_tests/ref_machine/test_baudelaire
+++ b/run_tests/ref_machine/test_baudelaire
@@ -401,7 +401,7 @@ do
   if [[ "${typ}" = "tap"* ]] ; then
     which tapenade 1>> $tdir/output_$tt 2> /dev/null ; retv=$?
     if test $retv != 0 ; then
-      source $HOME/bin/set_tapenade.sh		>> $tdir/output_$tt
+      source $tdir/set_tapenade.sh		>> $tdir/output_$tt
       which tapenade				>> $tdir/output_$tt
     fi
   fi

--- a/run_tests/ref_machine/update_scripts
+++ b/run_tests/ref_machine/update_scripts
@@ -99,5 +99,52 @@ if test ! -e $dNam ; then
 fi
 
 #---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+#- update Tapenade software:
+if test $thisComputer = 'baudelaire' ; then
+    tap_log='tapUpdate.log'
+    test -e $tap_log &&  mv -f $tap_log ${tap_log}_bak
+    date > $tap_log
+    # get latest tar file:
+    tapFile='tapenade_3.16'
+    rm -f $tapFile.tar
+    echo "- get latest '$tapFile.tar' file using:"	>> $tap_log
+    echo "  wget https://tapenade.gitlabpages.inria.fr/tapenade/distrib/$tapFile.tar" >> $tap_log
+    wget https://tapenade.gitlabpages.inria.fr/tapenade/distrib/$tapFile.tar >> $tap_log
+    retVal=$?
+    if test $retVal = 0 ; then
+      echo ' --> done!'					>> $tap_log
+    else echo ''
+      echo " Error: 'wget' returned: $retVal"		| tee -a $tap_log
+      exit 4
+    fi
+    if test -e $tapFile.inUse.tar ; then
+      diff -q $tapFile.tar $tapFile.inUse.tar > /dev/null 2>&1
+      retVal=$?
+      if test $retVal = 0 ; then
+        echo " no update to $tapFile.tar"		>> $tap_log
+      else
+        echo " will use updated version:"		>> $tap_log
+        mv -f $tapFile.inUse.tar $tapFile.prev.tar
+        mv    $tapFile.tar      $tapFile.inUse.tar
+        rm -rf $tapFile
+        ls -l $tapFile.inUse.tar $tapFile.prev.tar	>> $tap_log
+      fi
+    else
+      echo " no previous $tapFile.inUse.tar ; use new one" >> $tap_log
+      mv $tapFile.tar $tapFile.inUse.tar
+      rm -rf $tapFile
+    fi
+    if test ! -d $tapFile ; then
+      echo " un-tar file: $tapFile.inUse.tar"		>> $tap_log
+      tar -xf $tapFile.inUse.tar			>> $tap_log
+    fi
+    if test -x $dNam/set_tapenade.sh ; then
+      if test ! -e set_tapenade.sh ; then
+        echo " from '$dNam', link 'set_tapenade.sh':"	>> $tap_log
+        ln -s  $dNam/set_tapenade.sh .
+      fi
+    fi
+fi
+#---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #-- clean-up old log files:
 exit 0


### PR DESCRIPTION
For Tapenade daily tests on baudelaire, instead of using a frozen (old) version of Tapenade as done previously,

1. download the latest version form script `update_scripts`, and put it in main test-dir "~/test_baudelaire/".
2. switch to use the latest version by using an updated  `set_tapenade.sh` script which sets the Environment-variables and path to access the Tapenade version to use.