### PR TITLE
Minor update to output-message processing

### DIFF
--- a/collect_tests/check_outp
+++ b/collect_tests/check_outp
@@ -473,9 +473,9 @@ for pname in $MACHINES ; do
 	  #dd=`echo $optf | grep -c 'gfortran+mth'`
 	  #if test $mname = 'lagoon' -a $dd = 1 ; then num=-1 ; fi
 	  #if test $mname = 'aces' -a $optf = 'linux_ia32_g95' ; then num=-1 ; fi
-	  # dd=`echo $optf | grep -c 'linux_amd64_ifort+impi_engaging.fast'`
-	  # if test $dd = 1 -a $mname = 'engaging1' -a $type = 'restart' ; then num=-1 ; fi
-	  dd=`echo $sdir | grep -v 'engaging1-darwin3' | grep -c 'rs_engaging1-'`
+	  dd=`echo $optf | grep -c 'linux_amd64_ifort+impi_engaging.fast'`
+	  if test $dd = 1 -a $mname = 'engaging1' -a $type = 'restart' ; then num=-1 ; fi
+	  # dd=`echo $sdir | grep -v 'engaging1-darwin3' | grep -c 'rs_engaging1-'`
 	  # if test $dd = 1 ; then num=-1 ; fi
 	  if test $num -lt 0 ; then
 	    echo "-> discard: $sdir : $type , of='$optf'" | tee -a $OUTPFIL

--- a/collect_tests/crontab_gcm
+++ b/collect_tests/crontab_gcm
@@ -7,14 +7,12 @@ MAILTO=jmc@ocean.mit.edu
 55  * * * * /home/jm_c/testing/bin_sh/build_mitgcm_front
 35 23 * * * cd /home/jm_c/testing && ./daily_update && cp -p bin_sh/daily_update .
 35 01 * * * /home/jm_c/testing/bin_sh/mk_git_tarfile
-#38 10 * * * cd /home/jm_c/testing/website_legacy/front_content && ./make_summary -d 2023_11
+#38 10 * * * cd /home/jm_c/testing/website_legacy/front_content && ./make_summary -d 2025_03
 
-16 07  * * *  cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a 'jmc@mit.edu Martin.Losch@awi.de' > chk_outp.stdout
-16 09,11  * * *  cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a jmc@mit.edu > chk_outp.stdout
-
-#16 07,09,11  * * *  cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a jmc@mit.edu > chk_outp.stdout
-46 12,14,16,18 * * *  cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a jmc@mit.edu > chk_outp.stdout
-31 09 * * * cd /home/jm_c/testing/logs && ../bin_sh/check_outp -d yesterday -a jmc@mit.edu > chk_outp.stdout
+16 07  * * * cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a 'jmc@mit.edu Martin.Losch@awi.de' > chk_outp.stdout
+16 08,09,11,13,14,17 * * * cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a jmc@mit.edu > chk_outp.stdout
+46 18  * * * cd /home/jm_c/testing/logs && ../bin_sh/check_outp -t -a jmc@mit.edu > chk_outp.stdout
+31 09  * * * cd /home/jm_c/testing/logs && ../bin_sh/check_outp -d yesterday -a jmc@mit.edu > chk_outp.stdout
 
 #- Note: testreport output emails sent to: "jm_c@mitgcm.org" are put in
 #        ~/Mail/MITgcm-test on: jm_c@mitgcm-mm.mit.edu by procmail, using:

--- a/collect_tests/get+parse_msg
+++ b/collect_tests/get+parse_msg
@@ -218,7 +218,7 @@ fi
 #---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 #exit
 
-all_msg=`ls -1 $INDIR`
+all_msg=`ls -tr1 $INDIR`
 nb_msg=`echo "$all_msg" | grep -c '^msg\.'`
 nb_tar=`echo "$all_msg" | grep -c '\.tar\.gz$'`
 nb_files=`expr $nb_msg + $nb_tar`


### PR DESCRIPTION
Only minor changes:
1. process output-messages in the same order as message arrival, older first. This should bring more consistency in output-dir name (i.e., consistent suffix number) when multiple tests from the same platform use default  output-dir naming (with suffix number > 0).
2. discard 1 un-reliable restart test from `check_outp` comparison script.
3. keep the crontab document up-to-date