### PR TITLE
Fix and Adjust previous changes (from PR 19)

### DIFF
--- a/collect_tests/README
+++ b/collect_tests/README
@@ -47,7 +47,7 @@ LOGFILE=$MAILDIR/log    #recommended
 MITgcm-test
 
 :0
-! jmc@mit.edu
+! jm_c@mit.edu
 
 <----- File Ends here.
 

--- a/collect_tests/get+parse_msg
+++ b/collect_tests/get+parse_msg
@@ -114,12 +114,12 @@ if test ! -x $MUNPACK ; then
 fi
 
 #-- set OUTDIR (if not yet set) and create it (if not already there)
+oldMsg=0 ; nbTar=0
 if test "x$OUTDIR" = x ; then
   OUTDIR="$BASEDIR/$monthDir"
 else
   monthDir=0
 fi
-oldMsg=0
 if test ! -e $OUTDIR ; then
     mkdir $OUTDIR
     RETVAL=$?
@@ -140,7 +140,7 @@ if test ! -e $OUTDIR ; then
     if test $oldMsg != 0 ; then
       newInD=`dirname $INDIR`
       INDIR="$newInD/postponed"
-      echo " Change INDIR to '$INDIR' ($oldMsg old messages)"
+      echo " Change INDIR to '$INDIR' ($oldMsg old files)"
       oldMsg=1
     fi
 fi
@@ -239,7 +239,6 @@ EOF
         rm -f $TMP_RM $STDOUT
       fi
     fi
-    #echo " nbTar='$nbTar' ; listTar='$listTar'"
 
 #---------------------------------------------------------------------
 

--- a/run_tests/nasa_ames/test_pleiades_fast
+++ b/run_tests/nasa_ames/test_pleiades_fast
@@ -20,9 +20,9 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-#SEND="ssh pfe $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
-#SEND="ssh pfe scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
- SEND="ssh pfe $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
+#SEND="ssh pfe20 $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
+#SEND="ssh pfe20 scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
+ SEND="ssh pfe20 $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):

--- a/run_tests/nasa_ames/test_pleiades_fast1
+++ b/run_tests/nasa_ames/test_pleiades_fast1
@@ -20,9 +20,9 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-#SEND="ssh pfe $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
-#SEND="ssh pfe scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
- SEND="ssh pfe $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
+#SEND="ssh pfe20 $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
+#SEND="ssh pfe20 scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
+ SEND="ssh pfe20 $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):

--- a/run_tests/nasa_ames/test_pleiades_fast2
+++ b/run_tests/nasa_ames/test_pleiades_fast2
@@ -20,9 +20,9 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-#SEND="ssh pfe $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
-#SEND="ssh pfe scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
- SEND="ssh pfe $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
+#SEND="ssh pfe20 $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
+#SEND="ssh pfe20 scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
+ SEND="ssh pfe20 $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):

--- a/run_tests/nasa_ames/test_pleiades_ieee
+++ b/run_tests/nasa_ames/test_pleiades_ieee
@@ -20,9 +20,9 @@ echo " running on: "`hostname`
 dNam='pleiades'
 HERE="$HOME/test_$dNam"
 SubD="$HERE/$dNam" ; OUTP="$HERE/output" ; SavD="$HERE/send"
-#SEND="ssh pfe $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
-#SEND="ssh pfe scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
- SEND="ssh pfe $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
+#SEND="ssh pfe20 $SavD/mpack" ;       DESTIN="-sd $SavD -a jm_c@mitgcm.org"
+#SEND="ssh pfe20 scp" ;               DESTIN="-sd $SavD -a jm_c@mitgcm.org:testing/MITgcm-test"
+ SEND="ssh pfe20 $SavD/upload_sftp" ; DESTIN="-sd $SavD -a sftp_shared@svante8.mit.edu"
 TST_DISK="/nobackupp17/jcampin"
 TST_DIR="$TST_DISK/test_${dNam}"
 #- where local copy of code is (need to be consistent with "test_submit_pleiades"):

--- a/run_tests/other/test_local
+++ b/run_tests/other/test_local
@@ -57,7 +57,7 @@ if test $1 = tap ; then
 
   if test ! -e $gcmDIR/.git/config ; then
     echo " No current clone '${gcmDIR}' ==> get a fresh clone" >> $logFile
-    #rm -f git_Hash prevHash
+    rm -f git_Hash
     if test -d $gcmDIR ; then /bin/rm -rf $gcmDIR ; fi
     git clone https://github.com/$git_repo/${git_code}.git $gcmDIR ; retv=$?
     if test $retv != 0 ; then
@@ -223,7 +223,7 @@ do
   fi
  fi
   echo ""
-  echo "=========================================================================="
+  echo "--------------------------------------------------------------------------"
 
  if test -d $gcmDIR/verification ; then
   if test -e tr_run_$tt.log ; then mv -f tr_run_$tt.log tr_run_$tt.log_bak ; fi
@@ -440,6 +440,7 @@ esac
  fi
 
 done
+  echo "=========================================================================="
 
 if test $1 = gfort ; then
   day=`date +%d`

--- a/run_tests/other/test_update_local
+++ b/run_tests/other/test_update_local
@@ -4,6 +4,26 @@ gcmDIR="MITgcm"
 logFile='check_update.log'
 CronTabFile='crontab_jmc'
 
+#- to print debug info, set "dB" to something (e.g.: dB=0 );
+#                       otherwise set it to nothing ( dB= ):
+dB=
+
+#--------------------------
+dayInMonth=`date +%d`
+if test $dayInMonth = '01' ; then
+  tail -n 1 $logFile | grep -q '^==*$'
+  retVal=$?
+  if test $retVal != 0 ; then
+    echo "- first day of the month: add separation line to log-file: '$logFile'"
+    echo \
+    '================================================================================' \
+         >> $logFile
+  fi
+fi
+
+#--------------------------
+# after saving previous git-hash to "prevHash",
+# update $gcmDIR clone master branch and get the corresponding git-hash
 if test -f git_Hash ; then mv git_Hash prevHash ; fi
 if test -e $gcmDIR/.git/config ; then
   ( cd $gcmDIR ; git checkout master > /dev/null 2>&1 )
@@ -15,36 +35,44 @@ if test -e $gcmDIR/.git/config ; then
     echo "  'git pull' in $gcmDIR fail (return val=$retv) => no new 'git_Hash'" >> $logFile
     exit 1
   fi
+else
+  echo "Warning: no git clone '$gcmDIR' ==> no 'git_Hash' generated"
 fi
+
 #--------------------------
+#- rename previous non-empty "test_local" output : get list from crontab
 
 if test -r $CronTabFile ; then
   #-- get it from file
+  [ $dB ] && echo "- getting 'cronStuff' from file '$CronTabFile' :"
   cronStuff=`grep -v '^#' $CronTabFile | grep 'test_local .*>' | sed -e 's/^.*test_local //' -e 's/>*\&//'`
 else
   #-- get it from command
+  [ $dB ] && echo "- getting 'cronStuff' from command 'crontab -l' :"
   cronStuff=`crontab -l | grep -v '^#' | grep 'test_local .*>' | sed -e 's/^.*test_local //' -e 's/>*\&//'`
 fi
 
 pp=0
 for xx in $cronStuff ; do
-  #echo " xx='${xx}'"
+  # [ $dB ] && echo " xx='${xx}'"
   if test $pp = 0 ; then
     #-- set pair firt param:
     pp=$xx
   else
     #-- set pair second param:
-    #echo -n " pair of arg: pp='${pp}' & xx='${xx}'"
+    [ $dB ] && echo -n " pair of arg: pp='${pp}' & xx='${xx}'"
     namF=${xx}
     savF=`echo $namF | sed 's/_[0-9]*$/_/'`$pp
-    #echo " ; savF='${savF}'"
-    if test -e $namF ; then
-      #ls -l $namF
-      if test ! -s $namF ; then
-        #echo "mv $namF $savF"
+    [ $dB ] && echo " ; savF='${savF}'"
+    if test -f $namF ; then
+      [ $dB ] && ls -l $namF
+      if test -s $namF ; then
+        echo "mv $namF $savF"
         mv -f $namF $savF
+      else
+        [ $dB ] && echo " <-- empty file, do nothing"
       fi
-    #else echo " no file: $namF"
+     else [ $dB ] && echo " <-- no file: $namF"
     fi
     #-- reset pair firt param:
     pp=0


### PR DESCRIPTION
Make few small adjustments to previous PR #19 changes:
1.  fix postponed files processing in `collect_tests/get+parse_msg` (was missing "nbTar" initialization);
2.  fix condition for non-empty file in `run_tests/other/test_update_local` and improve debug + description.
3. for pleiades tests (in `run_tests/nasa_ames/test_pleiades_*`), switch to explicit head-node (here pick "pfe20") instead of generic "pfe" when ssh to head node to send output: This should avoid trying to ssh to a retired/down pfeXY.